### PR TITLE
Fix defaulting render texture size on Quest 2

### DIFF
--- a/desktop-app/src/app/adb-client.service.ts
+++ b/desktop-app/src/app/adb-client.service.ts
@@ -96,6 +96,7 @@ export class AdbClientService {
             );
         }).then((resp: string) => {
             this.adbResponse = resp.trim() || 'Command Completed.';
+            return resp.trim();
         });
     }
     launchApp(packageName) {
@@ -895,11 +896,11 @@ export class AdbClientService {
         name = name || packageId;
         const showTotal = number && total ? '(' + number + '/' + total + ') ' : '';
         if (!task) this.spinnerService.showLoader();
-        let p = this.runAdbCommand('adb push "' + filepath + '" /sdcard/Android/obb/' + packageId + '/' + filename);
+        let pAdb = this.runAdbCommand('adb push "' + filepath + '" /sdcard/Android/obb/' + packageId + '/' + filename);
         if (cb) {
             cb();
         }
-        p = p.then(() => {
+        let p = pAdb.then(() => {
             if (task) {
                 task.status = name + ' File transferred successfully! ';
             } else {

--- a/desktop-app/src/app/tools/tools.component.html
+++ b/desktop-app/src/app/tools/tools.component.html
@@ -186,7 +186,7 @@
       <div class="button-section">
         <div class="waves-effect waves-light btn set-sso margin-bottom margin-right pink-button"
           [ngClass]="{'button-dark-theme':appService.currentTheme === 'dark','button-light-theme':appService.currentTheme === 'light','waves-dark':true,'waves-light':false}"
-          (click)="setSSO(SSO._1024)">Default</div>
+          (click)="setSSOToDefault()">Default</div>
         <div class="waves-effect waves-light btn set-sso margin-bottom margin-right pink-button"
           [ngClass]="{'button-dark-theme':appService.currentTheme === 'dark','button-light-theme':appService.currentTheme === 'light','waves-dark':true,'waves-light':false}"
           (click)="setSSO(SSO._512)">512</div>

--- a/desktop-app/src/app/tools/tools.component.ts
+++ b/desktop-app/src/app/tools/tools.component.ts
@@ -171,6 +171,22 @@ export class ToolsComponent implements OnInit {
                 this.statusService.showStatus(e, true);
             });
     }
+    setSSOToDefault() {
+        this.runAdbCommand('adb shell getprop ro.product.model')
+            .then(model => {
+                switch (model) {
+                    case 'Quest 2':
+                        return this.setSSO(SSO._1536);
+                    case 'Quest':
+                        return this.setSSO(SSO._1024);
+                    default:
+                        throw new Error(`Unrecognized device model: ${model}`);
+                }
+            })
+            .catch(e => {
+                this.statusService.showStatus(e, true);
+            });
+    }
     setSSO(sso: SSO) {
         let value = 0;
         switch (sso) {


### PR DESCRIPTION
This makes SideQuest intelligently choose the correct resolution by detecting the target device model, `(Quest|Quest 2)`. This fixes #86. 