### PR TITLE
URI decode synthriderz filenames

### DIFF
--- a/desktop-app/src/app/synthrider.service.ts
+++ b/desktop-app/src/app/synthrider.service.ts
@@ -43,7 +43,7 @@ export class SynthriderService {
                         var regexp = /filename=\"(.*)\"/gi;
                         var _regResult = regexp.exec(response.headers['content-disposition']);
                         if (_regResult && _regResult.length) {
-                            zipPath = this.appService.path.join(this.appService.appData, _regResult[1]);
+                            zipPath = this.appService.path.join(this.appService.appData, decodeURIComponent(_regResult[1]));
                         }
                         request.pipe(this.appService.fs.createWriteStream(zipPath));
                     })


### PR DESCRIPTION
Filenames from synthriderz.com are percent encoded. This fixes synth riders file handling by URI decoding the extracted filename.

Before:
![sidequest-before](https://user-images.githubusercontent.com/8366326/97317967-5f89c900-1839-11eb-9ce4-d4cc4103c461.png)

After:
![sidequest-after](https://user-images.githubusercontent.com/8366326/97317978-61ec2300-1839-11eb-93fa-fc2708ff097e.png)
