### PR TITLE
Sort by game name

### DIFF
--- a/desktop-app/src/app/packages/packages.component.ts
+++ b/desktop-app/src/app/packages/packages.component.ts
@@ -134,8 +134,13 @@ export class PackagesComponent implements OnInit {
                             };
                         })
                         .sort((a, b) => {
-                            let textA = (a.name || a.packageName).toUpperCase();
-                            let textB = (b.name || b.packageName).toUpperCase();
+                            const getGameName = (packageName: string) => {
+                                const split = packageName.split('.');
+
+                                return split[split.length - 1];
+                            };
+                            let textA = (a.name || getGameName(a.packageName)).toUpperCase();
+                            let textB = (b.name || getGameName(b.packageName)).toUpperCase();
                             return textA < textB ? -1 : textA > textB ? 1 : 0;
                         });
                     this.myApps.forEach(p => {


### PR DESCRIPTION
Addresses #101 

Change sorting by parsing out the game name from the package and using that for the sort comparison. I'm happy to change this to prioritise games listed in the app-index instead if that's what you'd prefer. It does look a bit strange when mixing it all together. This is the visual result of my changes: 

Before: 
<img width="1320" alt="Screenshot 2021-01-23 at 15 28 36" src="https://user-images.githubusercontent.com/38016720/105580932-aed78b00-5d8f-11eb-916b-c8f312bc52b1.png">


After: 
<img width="865" alt="Screenshot 2021-01-23 at 15 19 21" src="https://user-images.githubusercontent.com/38016720/105580914-8f406280-5d8f-11eb-8c86-12ae4e0908f8.png">
