### PR TITLE
Update for Synth Riders directory change

### DIFF
--- a/desktop-app/src/app/header/header.component.ts
+++ b/desktop-app/src/app/header/header.component.ts
@@ -141,7 +141,7 @@ export class HeaderComponent implements OnInit {
                 break;
             case 'fileFavourites':
                 defaultFavs = `[
-            {"name":"SynthRiders", "uri": "/sdcard/Android/data/com.kluge.SynthRiders/files/CustomSongs/", "icon": "https://i.imgur.com/LjK7Z3o.png"},
+            {"name":"SynthRiders", "uri": "/sdcard/SynthRidersUC/", "icon": "https://i.imgur.com/cmH6q6D.png"},
             {"name":"Song Beater", "uri": "/sdcard/Android/data/com.Playito.SongBeater/CustomSongs/", "icon": "https://i.imgur.com/dOx0OEl.png"},
             {"name":"VRtuos", "uri": "/sdcard/Android/data/com.PavelMarceluch.VRtuos/files/Midis/", "icon": "https://i.imgur.com/7G0OpJi.png"},
             {"name":"Audica", "uri": "/sdcard/Audica/", "icon": "https://i.imgur.com/40sUjye.png"},

--- a/desktop-app/src/app/synthrider.service.ts
+++ b/desktop-app/src/app/synthrider.service.ts
@@ -55,10 +55,12 @@ export class SynthriderService {
                                 {
                                     name: zipPath,
                                     savePath:
-                                        '/sdcard/Android/data/com.kluge.SynthRiders/files/' +
+                                        '/sdcard/SynthRidersUC/' +
                                         (ext.toLowerCase() === '.synth'
                                             ? 'CustomSongs/'
-                                            : ext.toLowerCase() === '.stagequest'
+                                            : ext.toLowerCase() === '.playlist'
+                                            ? 'Playlist/'
+                                            : ext.toLowerCase() === '.stagequest' || ext.toLowerCase() === '.spinstagequest'
                                             ? 'CustomStages/'
                                             : 'Mods/') +
                                         basename,


### PR DESCRIPTION
Today's Synth Riders update changed the default custom content directory.

This pull request performs the following related fixes:

- Update favorites icon to point at the new content directory
- Update download handling to send downloads from synthriderz.com to the new content directory
- Update download handling to also handle Playlist files
- Update favorites icon image to the current Synth Riders game icon